### PR TITLE
fix: Wypst rendering on iOS Obsidian

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -23,16 +23,16 @@ export default class Wypst extends Plugin {
 
 		await loadMathJax();
 
-		if (!global.MathJax) {
+		if (!globalThis.MathJax) {
 			throw new Error("MathJax failed to load.");
 		}
 
 		await wypst.init(wasm);
 
 		const parser = new DOMParser();
-		this._tex2chtml = global.MathJax.tex2chtml;
+		this._tex2chtml = globalThis.MathJax.tex2chtml;
 
-		global.MathJax.tex2chtml = (e, r) => {
+		globalThis.MathJax.tex2chtml = (e, r) => {
 			if (!hasLatexCommand(e)) {
 				const renderSettings = {
 					displayMode: r.display,
@@ -65,7 +65,7 @@ export default class Wypst extends Plugin {
 	}
 
 	onunload() {
-		global.MathJax.tex2chtml = this._tex2chtml;
+		globalThis.MathJax.tex2chtml = this._tex2chtml;
 		this.app.workspace.getActiveViewOfType(MarkdownView)?.previewMode.rerender(true);
 	}
 }


### PR DESCRIPTION
Wypst rendering does not work on iOS Obsidian - it is treated and rendered as if it were normal Latex code.

This is because this plugin encountered an error referencing MathJax's rendering handler, and failed to replace it with Wypst's.

On some platforms, including iOS, the top-level object that can be referenced from Javascript appears to be `window` rather than `global`.

Therefore, I changed the way this plugin references the MathJax object from `global.MathJax` to `globalThis.MathJax` to make it platform-independent, and found that it works fine on both the Chromium-based Electron on MacOS and the WebKit view on iOS.